### PR TITLE
get 100 repos at a time, instead of 30

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ api.get = function(token, cb){
 	async.waterfall([
 		// Get all repositories
 		function(cb){
-			github.repos.getAll({}, cb);
+			github.repos.getAll({ per_page : 100, type: "public"}, cb);
 		},
 
 		// Keep only forks


### PR DESCRIPTION
getAll public returns ~140 repos for me so I had to up the limits here.

related to #1  but doesn't totally fix it. 