### PR TITLE
Remove 'promise' dependency

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,8 @@
 	"extends": "eslint:recommended",
 	"env": {
 		"node": true
+	},
+	"globals": {
+		"Promise": true
 	}
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "homepage": "https://github.com/denis-sokolov/remove-github-forks",
   "devDependencies": {
     "ava": "^0.15.2",
-    "eslint": "^3.1.1",
-    "promise": "^7.1.1"
+    "eslint": "^3.1.1"
   }
 }

--- a/src/githubFactory.js
+++ b/src/githubFactory.js
@@ -1,5 +1,4 @@
 var GithubLib = require('github')
-var Promise = require('promise')
 var queue = require('queue')
 
 var rawGithubFactory = function (token) {

--- a/test/lib/index.js
+++ b/test/lib/index.js
@@ -1,5 +1,3 @@
-var Promise = require('promise')
-
 exports.USER = { login: 'current-user' }
 exports.AUTHOR = { login: 'cool-author' }
 exports.COMMIT_A = { sha: 'abcdef1' }


### PR DESCRIPTION
`global.Promise` has been around since 0.12, so unless you support 0.10 (and by looking at [.travis.yml](https://github.com/denis-sokolov/remove-github-forks/blob/master/.travis.yml) you don't), it's best to remove it. Also because it's listed as a `devDependency` while it's used as a `dependency` (i.e. it currently fails on my computer)