### PR TITLE
Added no-confirmation option

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -39,7 +39,7 @@ var abort = function (err) {
   process.exit(1)
 }
 
-function deleteRepos(confirmed) {
+function deleteRepos(confirmed, repos) {
   if (!confirmed) {
     return abort('Aborting.')
   }
@@ -76,9 +76,11 @@ clean.get(token, {
       'Delete these forks: \n' + repos.map(function (repo) {
         return '    ' + repo.url
       }).join('\n') + '\n',
-      deleteRepos
+      function (confirmed) {
+        deleteRepos(confirmed, repos)
+      }
     )
   } else {
-    deleteRepos(true)
+    deleteRepos(true, repos)
   }
 })

--- a/src/bin.js
+++ b/src/bin.js
@@ -39,7 +39,7 @@ var abort = function (err) {
   process.exit(1)
 }
 
-function delete(confirmed) {
+function deleteRepos(confirmed) {
   if (!confirmed) {
     return abort('Aborting.')
   }
@@ -76,11 +76,9 @@ clean.get(token, {
       'Delete these forks: \n' + repos.map(function (repo) {
         return '    ' + repo.url
       }).join('\n') + '\n',
-      function (confirmed) {
-        delete(confirmed)
-      }
+      deleteRepos
     )
   } else {
-    delete(true)
+    deleteRepos(true)
   }
 })

--- a/src/bin.js
+++ b/src/bin.js
@@ -76,7 +76,9 @@ clean.get(token, {
       'Delete these forks: \n' + repos.map(function (repo) {
         return '    ' + repo.url
       }).join('\n') + '\n',
-      delete
+      function (confirmed) {
+        delete(confirmed)
+      }
     )
   } else {
     delete(true)

--- a/src/bin.js
+++ b/src/bin.js
@@ -13,6 +13,7 @@ program
   .version(meta.version)
   .usage('token')
   .option('--user <value>', 'Only cleanup given user or organization')
+  .option('-y', 'Do not ask for confirmation before deleting')
   .parse(process.argv)
 
 program.on('--help', function () {
@@ -24,6 +25,11 @@ program.on('--help', function () {
   console.log('')
 })
 
+var askConfirmation = true
+program.on('-y', function() {
+  askConfirmation = false
+})
+
 if (program.args.length !== 1) program.help()
 
 var token = program.args[0]
@@ -31,6 +37,17 @@ var token = program.args[0]
 var abort = function (err) {
   console.error(err.message || err)
   process.exit(1)
+}
+
+function delete(confirmed) {
+  if (!confirmed) {
+    return abort('Aborting.')
+  }
+  clean.remove(token, repos, function (errDeleting) {
+    if (errDeleting) return abort(errDeleting)
+    console.log('Done!')
+    process.exit(0)
+  })
 }
 
 clean.get(token, {
@@ -53,20 +70,15 @@ clean.get(token, {
     console.log('No useless repositories found.')
     process.exit(0)
   }
-
-  confirm(
-    'Delete these forks: \n' + repos.map(function (repo) {
-      return '    ' + repo.url
-    }).join('\n') + '\n',
-    function (confirmed) {
-      if (!confirmed) {
-        return abort('Aborting.')
-      }
-      clean.remove(token, repos, function (errDeleting) {
-        if (errDeleting) return abort(errDeleting)
-        console.log('Done!')
-        process.exit(0)
-      })
-    }
-  )
+  
+  if (askConfirmation) {
+    confirm(
+      'Delete these forks: \n' + repos.map(function (repo) {
+        return '    ' + repo.url
+      }).join('\n') + '\n',
+      delete
+    )
+  } else {
+    delete(true)
+  }
 })


### PR DESCRIPTION
Added a -y option to not ask for confirmation before deleting (for example, to run the program as a cron job). Then, people can automatically clean up forks weekly (or however often they choose).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/denis-sokolov/remove-github-forks/60)
<!-- Reviewable:end -->
