### PR TITLE
Add host specification

### DIFF
--- a/src/githubFactory.js
+++ b/src/githubFactory.js
@@ -8,7 +8,8 @@ var rawGithubFactory = function (token) {
   }
 
   var res = new GithubLib({
-    version: '3.0.0'
+    version: '3.0.0',
+    host: 'api.github.com'
   })
   res.authenticate({
     type: 'oauth',

--- a/src/githubFactory.js
+++ b/src/githubFactory.js
@@ -9,6 +9,8 @@ var rawGithubFactory = function (token) {
 
   var res = new GithubLib({
     version: '3.0.0',
+    // Apparently the default is not good enough, see
+    // https://github.com/denis-sokolov/remove-github-forks/issues/62
     host: 'api.github.com'
   })
   res.authenticate({


### PR DESCRIPTION
Fixes #62. Specified the API host to prevent "Cookies must be enabled to use GitHub" error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/denis-sokolov/remove-github-forks/63)
<!-- Reviewable:end -->
