### PR TITLE
Update to @octokit/rest

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "async": "^2.0.1",
     "commander": "^2.5.0",
     "confirm-simple": "^1.0.3",
-    "github": "^13.0.1",
+    "@octokit/rest": "^14.0.0",
     "queue": "^4.0.0",
     "single-line-log": "^1.1.1"
   },

--- a/src/githubFactory.js
+++ b/src/githubFactory.js
@@ -1,4 +1,4 @@
-var GithubLib = require('github')
+var GithubLib = require('@octokit/rest')
 var queue = require('queue')
 
 var rawGithubFactory = function (token) {


### PR DESCRIPTION
Update to use `@octokit/rest` instead of the `github` package.

As of [v14.0.0] `github` was moved to [`@octokit/rest`][octokit/rest].

The API is identical, this just stops it displaying a deprecation error when installing. :+1:

[octokit/rest]: https://www.npmjs.com/package/@octokit/rest
[v14.0.0]: https://github.com/octokit/rest.js/releases/tag/v14.0.0