### PR TITLE
fix: mergeable no empty option for description

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -6,4 +6,4 @@ mergeable:
     description:
       must_exclude:
         regex: '\[ \]'
-      no-empty: false
+      no_empty: false


### PR DESCRIPTION
## Context
The mergeable README has some errors. The correct tag should be `no_empty`. Note: the mergeable/README has conflicting examples `no-empty` and `no_empty`.