### PR TITLE
Remove almost-EOL Node.js v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "12"
 script:
   "npm run ci"
-sudo: false


### PR DESCRIPTION
https://nodejs.org/en/about/releases/

Also `sudo` is no longer needed: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
