### PR TITLE
Move from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,5 +26,4 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: npm ci
-      - run: npm run build
       - run: npx ava

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  - pull_request
+  - push
+
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run format-verify
+
+  Test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node:
+          - 10
+          - 12
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm ci
+      - run: npm run build
+      - run: npx ava

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,12 @@
 name: CI
 
 on:
-  - pull_request
-  - push
+  pull_request:
+    branches: 
+      - '*'
+  push:
+    branches: 
+      - master
 
 jobs:
   Lint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,4 +26,4 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: npm ci
-      - run: npx ava
+      - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - "10"
-  - "12"
-script:
-  "npm run ci"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "format-verify": "prettier --check 'src/**/*.{js,md}' *.{js,md}",
     "lint": "eslint src",
     "test": "ava test/*.js",
-    "ci": "npm run lint && npm run format-verify && npm run test",
     "prepublishOnly": "npm run ci"
   },
   "keywords": [


### PR DESCRIPTION
Travis doesn't seem to be working so I thought this could be moved to GHA. The advantage is that it's faster and looks better (linting and building can be multiple parallel steps)

This should be equivalent to the current Travis configuration.

This doesn't run here yet because it hasn't been merged into this repository, but you can see it running on my repo here: https://github.com/fregante/remove-github-forks/actions/runs/271916397