### PR TITLE
Use repository default branch instead of always "master"

### DIFF
--- a/src/should-delete-fork.js
+++ b/src/should-delete-fork.js
@@ -14,7 +14,7 @@ const branchIsUseful = async (github, repo, branch, parentBranches) => {
 	// Looping through all parent branches is immensely slow,
 	// let's take a safe shortcut
 	const branchesToCheck = parentBranches.filter(b => {
-		return [branch.name, 'master'].includes(b.name);
+		return [branch.name, repo.default_branch].includes(b.name);
 	});
 	for (const candidate of branchesToCheck) {
 		try {

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -66,10 +66,10 @@ exports.mock = responses => {
 		{name: 'fork1', fork: true, owner: exports.USER}
 	];
 	responses.get = responses.get || {
+		default_branch: 'master',
 		name: 'fork1',
 		owner: exports.USER,
-		parent: {name: 'upstream-lib', owner: exports.AUTHOR},
-		default_branch: 'master'
+		parent: {name: 'upstream-lib', owner: exports.AUTHOR}
 	};
 
 	const calls = [];

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -68,7 +68,8 @@ exports.mock = responses => {
 	responses.get = responses.get || {
 		name: 'fork1',
 		owner: exports.USER,
-		parent: {name: 'upstream-lib', owner: exports.AUTHOR}
+		parent: {name: 'upstream-lib', owner: exports.AUTHOR},
+		default_branch: 'master'
 	};
 
 	const calls = [];

--- a/test/simple.js
+++ b/test/simple.js
@@ -82,7 +82,7 @@ test.cb('should not delete a fork that has more branches', t => {
 	});
 });
 
-test.cb.only('should correctly check against the default branch', t => {
+test.cb('should correctly check against the default branch', t => {
 	const mock = lib.mock({
 		get: {
 			default_branch: 'main',

--- a/test/simple.js
+++ b/test/simple.js
@@ -85,10 +85,10 @@ test.cb('should not delete a fork that has more branches', t => {
 test.cb.only('should correctly check against the default branch', t => {
 	const mock = lib.mock({
 		get: {
+			default_branch: 'main',
 			name: 'fork1',
 			owner: lib.USER,
-			parent: {name: 'upstream-lib', owner: lib.AUTHOR},
-			default_branch: 'main',
+			parent: {name: 'upstream-lib', owner: lib.AUTHOR}
 		},
 		listBranches(arguments_) {
 			if (arguments_.user === lib.USER.login) {

--- a/test/simple.js
+++ b/test/simple.js
@@ -82,6 +82,49 @@ test.cb('should not delete a fork that has more branches', t => {
 	});
 });
 
+test.cb.only('should correctly check against the default branch', t => {
+	const mock = lib.mock({
+		get: {
+			name: 'fork1',
+			owner: lib.USER,
+			parent: {name: 'upstream-lib', owner: lib.AUTHOR},
+			default_branch: 'main',
+		},
+		listBranches(arguments_) {
+			if (arguments_.user === lib.USER.login) {
+				return [
+					{name: 'bar', commit: lib.COMMIT_A}
+				];
+			}
+
+			return [
+				{name: 'main', commit: lib.COMMIT_A},
+				{name: 'master', commit: lib.COMMIT_C},
+				{name: 'baz', commit: lib.COMMIT_B}
+			];
+		},
+		delete: true
+	});
+
+	removeGithubForks(mock.present, error => {
+		if (error) {
+			return t.fail(error);
+		}
+
+		lib.check(t, mock.calls(), [
+			['listForAuthenticatedUser', {type: 'public'}],
+			['get', {owner: lib.USER.login, repo: 'fork1'}],
+			['listBranches', {owner: lib.USER.login, repo: 'fork1', per_page: 100}],
+			[
+				'listBranches',
+				{owner: lib.AUTHOR.login, repo: 'upstream-lib', per_page: 100}
+			],
+			['delete', {owner: lib.USER.login, repo: 'fork1', url: undefined}]
+		]);
+		t.end();
+	});
+});
+
 test.cb(
 	'should delete a fork that has more branches, but all at upstream branch tips',
 	t => {


### PR DESCRIPTION
Since a lot of repo's now no longer use `master` as default branch the tool reports false positives.

But by using the `default_branch` property of the repo this should always work as expected.